### PR TITLE
Add protocol to make URL work in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 ## Notes
 
-Landing Page for [igo.mskcc.org](igo.mskcc.org), linking to tools like Sample Submission and QC.
+Landing Page for [igo.mskcc.org](http://igo.mskcc.org), linking to tools like Sample Submission and QC.
 - https://github.com/mskcc/sample-submission-frontend
 - https://github.com/mskcc/sample-submission-backend
 - https://github.com/mskcc/igo-sample-qc-backend


### PR DESCRIPTION
For me these URLs differ:

https://igo.mskcc.org

and

http://igo.mskcc.org

Not sure which one this should point to